### PR TITLE
Update-AzureRMVmss incorrect parameter fix

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-manage-powershell.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-manage-powershell.md
@@ -60,7 +60,7 @@ $vmss = Get-AzureRmVmss -ResourceGroupName "myResourceGroup" -VMScaleSetName "my
 
 # Set and update the capacity of your scale set
 $vmss.sku.capacity = 5
-Update-AzureRmVmss -ResourceGroupName "myResourceGroup" -VMScaleSetName "myScaleSet" -VirtualMachineScaleSet $vmss 
+Update-AzureRmVmss -ResourceGroupName "myResourceGroup" -Name "myScaleSet" -VirtualMachineScaleSet $vmss 
 ```
 
 Als duurt een paar minuten bijwerken van de capaciteit van de schaal is ingesteld. Als u verlaagt de capaciteit van een schaal ingesteld, wordt de virtuele machines met de hoogste exemplaar id's eerst worden verwijderd.


### PR DESCRIPTION
The Update-AzureRMVmss cmdlet parameter -VMScaleSetName doesn't exist.  The cmdlet is looking for -Name in it's place.  Modified page to reflect this.