### PR TITLE
Update README.md - Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ U kunt herbruikbare blokken met conAtent maken die moeten worden opgenomen in ee
 Alle artikelen in deze bibliotheek gebruiken GitHub-markdown.  Hier volgt een lijst van resources.
 
 * [Basisprincipes van markdown](https://help.github.com/articles/markdown-basics/)
-* [Afdrukbare cheatsheet voor markdown](./contributor-guide/media/documents/markdown-cheatsheet.pdf?raw=true)
+* [Afdrukbare cheatsheet voor markdown](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
 
 
 ## <a name="labels"></a>Labels


### PR DESCRIPTION
The Markdown Cheatsheet Online PDF link was broken and has been replaced
with the GitHub Guides hosted file in line with the original documentations

https://github.com/MicrosoftDocs/azure-docs/pull/4459