### PR TITLE
Update functions-create-first-function-vs-code.md

### DIFF
--- a/articles/azure-functions/functions-create-first-function-vs-code.md
+++ b/articles/azure-functions/functions-create-first-function-vs-code.md
@@ -147,7 +147,7 @@ In Visual Studio Code kunt u uw functieproject rechtstreeks in Azure publiceren.
 
 In dit artikel wordt ervan uitgegaan dat u een nieuwe functie-app maakt. Als u in een bestaande functie-app publiceert, wordt de inhoud van die app in Azure overschreven.
 
-1. Ga naar het gebied **Azure: Functions** en selecteer het pictogram Deploy to Function App (uitrollen naar functie-app).
+1. Ga naar het gebied **Azure: Functions** en selecteer het pictogram Deploy to Function App (Implementeren naar functie-app).
 
     ![Instellingen voor functie-app](./media/functions-create-first-function-vs-code/function-app-publish-project.png)
 
@@ -165,7 +165,7 @@ In dit artikel wordt ervan uitgegaan dat u een nieuwe functie-app maakt. Als u i
 
     De functie-app wordt gemaakt nadat u de locatie hebt gekozen. Nadat de functie-app is gemaakt en het implementatiepakket is toegepast, wordt er een melding weergegeven.
 
-1. Selecteer in de meldingen de optie **View Output** (Uitvoer weergeven) om de resultaten van het maken en uitrollen te bekijken, inclusief de Azure-resources die u hebt gemaakt.
+1. Selecteer in de meldingen de optie **View Output** (Uitvoer weergeven) om de resultaten van het maken en implementeren te bekijken, inclusief de Azure-resources die u hebt gemaakt.
 
     ![Uitvoer van het maken van de functie-app](./media/functions-create-first-function-vs-code/function-create-notifications.png)
 

--- a/articles/azure-functions/functions-create-first-function-vs-code.md
+++ b/articles/azure-functions/functions-create-first-function-vs-code.md
@@ -23,7 +23,7 @@ ms.locfileid: "49116657"
 
 Met Azure Functions kunt u uw code in een [serverloze](https://azure.microsoft.com/solutions/serverless/) omgeving uitvoeren zonder dat u eerst een virtuele machine moet maken of een webtoepassing publiceren.
 
-In dit artikel leert u hoe u de [Azure Functions extension for Visual Studio Code] (Azure Functions-extensie voor Visual Studio Code) gebruikt om met Microsoft Visual Studio Code een 'hello world'-functie op uw lokale computer maakt en test. Vervolgens publiceert u de functiecode vanuit Visual Studio Code op Azure.
+In dit artikel leert u hoe u de [Azure Functions extension for Visual Studio Code] (Azure Functions-extensie voor Visual Studio Code) gebruikt om met Microsoft Visual Studio Code een 'hello world'-functie op uw lokale computer te maken en te testen. Vervolgens publiceert u de functiecode vanuit Visual Studio Code op Azure.
 
 ![Azure-functiecode in een Visual Studio-project](./media/functions-create-first-function-vs-code/functions-vscode-intro.png)
 
@@ -147,7 +147,7 @@ In Visual Studio Code kunt u uw functieproject rechtstreeks in Azure publiceren.
 
 In dit artikel wordt ervan uitgegaan dat u een nieuwe functie-app maakt. Als u in een bestaande functie-app publiceert, wordt de inhoud van die app in Azure overschreven.
 
-1. Ga naar het gebied **Azure: Functions** en selecteer het pictogram Deploy to Function App (Implementeren naar functie-app).
+1. Ga naar het gebied **Azure: Functions** en selecteer het pictogram Deploy to Function App (uitrollen naar functie-app).
 
     ![Instellingen voor functie-app](./media/functions-create-first-function-vs-code/function-app-publish-project.png)
 
@@ -165,7 +165,7 @@ In dit artikel wordt ervan uitgegaan dat u een nieuwe functie-app maakt. Als u i
 
     De functie-app wordt gemaakt nadat u de locatie hebt gekozen. Nadat de functie-app is gemaakt en het implementatiepakket is toegepast, wordt er een melding weergegeven.
 
-1. Selecteer in de meldingen de optie **View Output** (Uitvoer weergeven) om de resultaten van het maken en implementeren te bekijken, inclusief de Azure-resources die u hebt gemaakt.
+1. Selecteer in de meldingen de optie **View Output** (Uitvoer weergeven) om de resultaten van het maken en uitrollen te bekijken, inclusief de Azure-resources die u hebt gemaakt.
 
     ![Uitvoer van het maken van de functie-app](./media/functions-create-first-function-vs-code/function-create-notifications.png)
 


### PR DESCRIPTION
A minor grammatical correction, and changed translation of deploy in "uitrollen" instead of "implementeren". "Uitrollen" is commonly used in software as a term for deployment, whereas "implementeren" is similar to "implement".